### PR TITLE
Change package type to symfony-pack

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "symfony-cmf/cmf-phpcr-dbal-pack",
   "description": "Meta repository to install dbal implementation of with doctrine/phpcr-dbal-symfony-pack.",
-  "type": "symfony-bundle",
+  "type": "symfony-pack",
   "require": {
     "doctrine/phpcr-dbal-symfony-pack": "^1.0",
     "symfony-cmf/symfony-cmf": "^2.1"


### PR DESCRIPTION
A `type` of a package should not be `symfony-bundle`, because this is not a bundle, this is a pack.

I found it when i tried to update automaticaly merged PR for this package, and PR did not pass flex bot validation. See https://github.com/symfony/recipes-contrib/pull/382